### PR TITLE
Implement array conversions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,3 +429,22 @@ where
         Self::from_slice(slice)
     }
 }
+
+impl<T, const N: usize> From<[T; N]> for StaticVec<T, N> {
+    fn from(array: [T; N]) -> Self {
+        let mut vec = Self::new();
+        for element in array {
+            unsafe { vec.push_unchecked(element) };
+        }
+        vec
+    }
+}
+
+impl<T, const N: usize> From<StaticVec<T, N>> for [T; N] {
+    fn from(mut vec: StaticVec<T, N>) -> Self {
+        unsafe {
+            vec.len = 0;
+            ptr::read(vec.as_ptr() as *const [T; N])
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use core::{
     borrow::{Borrow, BorrowMut},
-    convert::{AsMut, AsRef},
+    convert::{AsMut, AsRef, TryFrom},
     fmt,
     hash::{Hash, Hasher},
     iter::{FromIterator, IntoIterator},
@@ -440,11 +440,19 @@ impl<T, const N: usize> From<[T; N]> for StaticVec<T, N> {
     }
 }
 
-impl<T, const N: usize> From<StaticVec<T, N>> for [T; N] {
-    fn from(mut vec: StaticVec<T, N>) -> Self {
-        unsafe {
-            vec.len = 0;
-            ptr::read(vec.as_ptr() as *const [T; N])
+impl<T, const N: usize> TryFrom<StaticVec<T, N>> for [T; N] {
+    type Error = ();
+
+    /// Converts the static vector into an array.
+    /// This only succeedes if the vector is full and thus actually contains `N` initialized elements.
+    fn try_from(mut vec: StaticVec<T, N>) -> Result<Self, Self::Error> {
+        if vec.is_full() {
+            unsafe {
+                vec.len = 0;
+                Ok(ptr::read(vec.as_ptr() as *const [T; N]))
+            }
+        } else {
+            Err(())
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -194,3 +194,19 @@ fn remove() {
     assert_eq!(v.remove(0), 1);
     assert_eq!(v.len(), 0);
 }
+
+#[test]
+fn array_conversion() {
+    let input = [1, 2, 3, 4];
+
+    // While feature(generic_arg_infer) is open, we cannot infer the capacity.
+    let v: StaticVec<_, 4> = input.into();
+    assert_eq!(v.len(), 4);
+    assert_eq!(v[0], 1);
+    assert_eq!(v[1], 2);
+    assert_eq!(v[2], 3);
+    assert_eq!(v[3], 4);
+
+    let output: [i32; 4] = v.into();
+    assert_eq!(output, input);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use core::convert::TryInto;
+
 use crate::StaticVec;
 
 #[test]
@@ -200,13 +202,18 @@ fn array_conversion() {
     let input = [1, 2, 3, 4];
 
     // While feature(generic_arg_infer) is open, we cannot infer the capacity.
-    let v: StaticVec<_, 4> = input.into();
+    let mut v: StaticVec<_, 4> = input.into();
     assert_eq!(v.len(), 4);
     assert_eq!(v[0], 1);
     assert_eq!(v[1], 2);
     assert_eq!(v[2], 3);
     assert_eq!(v[3], 4);
 
-    let output: [i32; 4] = v.into();
-    assert_eq!(output, input);
+    let output: Result<[i32; 4], _> = v.clone().try_into();
+    assert!(output.is_ok());
+    assert_eq!(output.unwrap(), input);
+
+    v.pop().unwrap();
+    let output: Result<[i32; 4], _> = v.clone().try_into();
+    assert!(output.is_err());
 }


### PR DESCRIPTION
`StaticVec<T, N>` can be converted from and to `[T; N]` without cloning the elements.