### PR TITLE
Refactor `push()` into `try_push()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ impl<T, const N: usize> StaticVec<T, N> {
     /// Appends a new element to the end of the vector.
     ///
     /// If the vector is already full then the element is returned.
-    pub fn push(&mut self, value: T) -> Result<(), T> {
+    pub fn try_push(&mut self, value: T) -> Result<(), T> {
         if self.is_full() {
             Err(value)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,14 @@ impl<T, const N: usize> StaticVec<T, N> {
         }
     }
 
+    /// Appends a new element to the end of the vector.
+    ///
+    /// Panics if the vector is already full.
+    pub fn push(&mut self, value: T) {
+        assert!(!self.is_full());
+        unsafe { self.push_unchecked(value) };
+    }
+
     /// Takes a last element of the vector *without checking whether the vector is empty*.
     pub unsafe fn pop_unchecked(&mut self) -> T {
         self.len -= 1;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -98,10 +98,10 @@ fn drop() {
     assert_eq!(Rc::strong_count(&b), 1);
 
     let mut v = StaticVec::<Rc<()>, 4>::new();
-    v.try_push(a.clone()).unwrap();
-    v.try_push(a.clone()).unwrap();
-    v.try_push(b.clone()).unwrap();
-    v.try_push(b.clone()).unwrap();
+    v.push(a.clone());
+    v.push(a.clone());
+    v.push(b.clone());
+    v.push(b.clone());
     v.try_push(b.clone()).unwrap_err();
     assert_eq!(Rc::strong_count(&a), 3);
     assert_eq!(Rc::strong_count(&b), 3);
@@ -142,7 +142,7 @@ fn fmt() {
     v.extend_from_slice(&[0, 1, 2]);
     assert_eq!(format!("{:?}", &v), "[0, 1, 2]");
 
-    v.try_push(3).unwrap();
+    v.push(3);
     assert_eq!(format!("{:?}", &v), "[0, 1, 2, 3]");
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -43,7 +43,7 @@ fn push_pop() {
     assert_eq!(v.len(), 0);
 
     for i in 0..3 {
-        assert_eq!(v.push(i as i32), Ok(()));
+        assert_eq!(v.try_push(i as i32), Ok(()));
     }
     assert_eq!(v.len(), 3);
     for i in 0..v.len() {
@@ -56,8 +56,8 @@ fn push_pop() {
         assert_eq!(*x, i as i32);
     }
 
-    assert_eq!(v.push(3), Ok(()));
-    assert_eq!(v.push(4), Err(4));
+    assert_eq!(v.try_push(3), Ok(()));
+    assert_eq!(v.try_push(4), Err(4));
     assert_eq!(v.len(), 4);
     for i in 0..v.len() {
         assert_eq!(v[i], i as i32);
@@ -98,11 +98,11 @@ fn drop() {
     assert_eq!(Rc::strong_count(&b), 1);
 
     let mut v = StaticVec::<Rc<()>, 4>::new();
-    v.push(a.clone()).unwrap();
-    v.push(a.clone()).unwrap();
-    v.push(b.clone()).unwrap();
-    v.push(b.clone()).unwrap();
-    v.push(b.clone()).unwrap_err();
+    v.try_push(a.clone()).unwrap();
+    v.try_push(a.clone()).unwrap();
+    v.try_push(b.clone()).unwrap();
+    v.try_push(b.clone()).unwrap();
+    v.try_push(b.clone()).unwrap_err();
     assert_eq!(Rc::strong_count(&a), 3);
     assert_eq!(Rc::strong_count(&b), 3);
 
@@ -142,7 +142,7 @@ fn fmt() {
     v.extend_from_slice(&[0, 1, 2]);
     assert_eq!(format!("{:?}", &v), "[0, 1, 2]");
 
-    v.push(3).unwrap();
+    v.try_push(3).unwrap();
     assert_eq!(format!("{:?}", &v), "[0, 1, 2, 3]");
 }
 


### PR DESCRIPTION
The current `push()` function requires a trailling `.unwrap()` in each usage to mute the unused-result warning.

In my use case this is redundant because my algorithm will never push more than `N` items, which is why I use `StaticVec` in the first place.

It is also somewhat surprising that the current `push()` function returns a `Result` because `Vec::push()` does not.

This PR does thus:
- Rename `push` to `try_push`
- Implement a new `push` function which panics if the vector is out of memory.